### PR TITLE
Fix npc_hologram bugs

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
@@ -147,12 +147,12 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
                         List<NPC> affectedNpcs = new ArrayList<>();
                         for (int id : settings.getIntegerList("npcs")) {
                             NPC npc = CitizensAPI.getNPCRegistry().getById(id);
-                            if (npc != null) {
+                            if (npc != null && npcs.containsKey(npc)) {
                                 affectedNpcs.add(npc);
                             }
                         }
 
-                        for (NPC npc : affectedNpcs.isEmpty() ? npcs.keySet() : affectedNpcs) {
+                        for (NPC npc : settings.getIntegerList("npcs").size() == 0 ? npcs.keySet() : affectedNpcs) {
                             NPCHologram npcHologram = new NPCHologram();
                             npcHologram.config = hologramConfig;
                             npcs.get(npc).add(npcHologram);
@@ -162,11 +162,11 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
                 }
 
                 Bukkit.getPluginManager().registerEvents(instance, BetonQuest.getPlugin());
-                runTaskTimer(BetonQuest.getPlugin(), 1, interval);
+
             }
         }, 3);
 
-
+        runTaskTimer(BetonQuest.getPlugin(), 4, interval);
         enabled = true;
     }
 


### PR DESCRIPTION
Changes:
  * Reloading quicker than 3 ticks resulted in a NPE.
  * If an npc exists but is not registered with BQ then a NPE results if its selected in a hologram npc list
  * If an npc list exists at all with greater than 0 items then it will not be considered a default if none of the NPC's actually exist