### PR TITLE
Compatibility with HolographicDisplays  now supports items defined in items.yml

### DIFF
--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/citizens/CitizensHologram.java
@@ -31,9 +31,12 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.ConditionID;
+import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.ItemID;
 import pl.betoncraft.betonquest.ObjectNotFoundException;
 import pl.betoncraft.betonquest.config.Config;
 import pl.betoncraft.betonquest.config.ConfigPackage;
+import pl.betoncraft.betonquest.item.QuestItem;
 import pl.betoncraft.betonquest.utils.Debug;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
 
@@ -114,6 +117,7 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
                         }
 
                         HologramConfig hologramConfig = new HologramConfig();
+                        hologramConfig.pack = pack;
 
                         try {
                             String vectorParts[] = settings.getString("vector", "0;3;0").split(";");
@@ -232,7 +236,25 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
                             hologram.getVisibilityManager().setVisibleByDefault(false);
                             for (String line : npcHologram.config.settings.getStringList("lines")) {
                                 if (line.startsWith("item:")) {
-                                    hologram.appendItemLine(new ItemStack(Material.matchMaterial(line.substring(5))));
+                                	try	{
+										String args[] = line.substring(5).split(":");
+										ItemID itemID = new ItemID(npcHologram.config.pack, args[0]);
+										int stackSize = 1;
+										try	{
+											stackSize = Integer.valueOf(args[1]);
+										}
+										catch(NumberFormatException e) {
+										}
+										ItemStack stack = new QuestItem(itemID).generate(stackSize);
+										stack.setAmount(stackSize);
+										hologram.appendItemLine(stack);
+									}
+									catch(InstructionParseException e) {
+										Debug.error("Could not parse item " + line.substring(5) + " hologram: " + e.getMessage());
+									}
+									catch(ObjectNotFoundException e) {
+										Debug.error("Could not find item in " + line.substring(5).split(":")[0] + " hologram: " + e.getMessage());
+									}
                                 } else {
                                     hologram.appendTextLine(line.replace('&', '§'));
                                 }
@@ -313,6 +335,6 @@ public class CitizensHologram extends BukkitRunnable implements Listener {
         private List<ConditionID> conditions;
         private Vector vector;
         private ConfigurationSection settings;
-
+        private ConfigPackage pack;
     }
 }

--- a/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HologramLoop.java
+++ b/BetonQuest-core/src/main/java/pl/betoncraft/betonquest/compatibility/holographicdisplays/HologramLoop.java
@@ -29,10 +29,12 @@ import org.bukkit.scheduler.BukkitRunnable;
 import pl.betoncraft.betonquest.BetonQuest;
 import pl.betoncraft.betonquest.ConditionID;
 import pl.betoncraft.betonquest.InstructionParseException;
+import pl.betoncraft.betonquest.ItemID;
 import pl.betoncraft.betonquest.ObjectNotFoundException;
 import pl.betoncraft.betonquest.QuestRuntimeException;
 import pl.betoncraft.betonquest.config.Config;
 import pl.betoncraft.betonquest.config.ConfigPackage;
+import pl.betoncraft.betonquest.item.QuestItem;
 import pl.betoncraft.betonquest.utils.Debug;
 import pl.betoncraft.betonquest.utils.LocationData;
 import pl.betoncraft.betonquest.utils.PlayerConverter;
@@ -99,7 +101,24 @@ public class HologramLoop {
                 for (String line : lines) {
                     // If line begins with 'item:', then we will assume its a floating item
                     if (line.startsWith("item:")) {
-                        hologram.appendItemLine(new ItemStack(Material.matchMaterial(line.substring(5))));
+						try	{
+							String args[] = line.substring(5).split(":");
+							ItemID itemID = new ItemID(pack, args[0]);
+							int stackSize = 1;
+							try	{
+								stackSize = Integer.valueOf(args[1]);
+							}
+							catch(NumberFormatException e) {
+							}
+							ItemStack stack = new QuestItem(itemID).generate(stackSize);
+							hologram.appendItemLine(stack);
+						}
+						catch(InstructionParseException e) {
+							Debug.error("Could not parse item in " + key + " hologram: " + e.getMessage());
+						}
+						catch(ObjectNotFoundException e) {
+							Debug.error("Could not find item in " + key + " hologram: " + e.getMessage());
+						}
                     } else {
                         hologram.appendTextLine(line.replace('&', '§'));
                     }

--- a/docs/10-Compatibility.md
+++ b/docs/10-Compatibility.md
@@ -316,12 +316,12 @@ In order to create a hologram, you have to add `holograms` section in your _cust
       beton:
         lines:
         - '&bThis is Beton.'
-        - 'item:MAP'
+        - 'item:map:1'
         - '&eBeton is strong.'
         location: 100;200;300;world
         conditions: has_some_quest, !finished_some_quest
 
-A line can also represent a floating item. To do so enter the line as 'item:`MATERIAL`'. It will be replaced with the `MATERIAL` defined. In the above example, a floating map will be seen between two lines of text.
+A line can also represent a floating item. To do so enter the line as 'item:`ITEM`'. It will be replaced with the `Item` defined in the items.yml. Default amount is 1. In the above example, a floating map will be seen between two lines of text.
 
 The holograms are updated every 10 seconds. If you want to make it faster, add `hologram_update_interval` option in _config.yml_ file and set it to a number of ticks you want to pass between updates (one second is 20 ticks). Don't set it to 0 or negative numbers, it will result in an error.
 


### PR DESCRIPTION
this feature add support, that you can define your items in the items.yml and set a amount of items in the custom.yml.
The amount only works at the moment with the code of this PR(https://github.com/filoghost/HolographicDisplays/pull/224) and in the future when the PR is accepted, so we maybe need to wait a little bit.

This change is compatible with old HolographicDisplays versions, but then the amount is ignored. 

Here is a little preview: https://cdn.discordapp.com/attachments/520955035832811521/620708922709377024/2019-09-09_21.53.58.png
There is also a video: https://drive.google.com/file/d/1bRmnnhVld9UT_9XfZMzusTRCtFLKPA35/view?usp=sharing
And a picture of multible Items in HolographicDisplays: https://cdn.discordapp.com/attachments/520955035832811521/622204749374029824/2019-09-14_00.58.13.png